### PR TITLE
Create fewer resources

### DIFF
--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/annotation/processor/NimbusAnnotationProcessor.java
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/annotation/processor/NimbusAnnotationProcessor.java
@@ -114,6 +114,8 @@ public class NimbusAnnotationProcessor extends AbstractProcessor {
 
     private List<FunctionInformation> functions = new LinkedList<>();
 
+    private UserConfigValidator userConfigValidator = new UserConfigValidator();
+
     private Messager messager;
 
     @Override
@@ -126,11 +128,14 @@ public class NimbusAnnotationProcessor extends AbstractProcessor {
         nativeImageReflectionWriter = new NativeImageReflectionWriter(fileWriter);
         userConfig = new ReadUserConfigService().readUserConfig();
 
+        userConfigValidator.validateUserConfig(userConfig, messager);
+
         Calendar cal = Calendar.getInstance();
         SimpleDateFormat simpleDateFormat =
                 new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSzzz", Locale.US);
 
         String compilationTime = simpleDateFormat.format(cal.getTime());
+
         processingData = new ProcessingData(
                 new NimbusState(
                         userConfig.getProjectName(),
@@ -142,7 +147,8 @@ public class NimbusAnnotationProcessor extends AbstractProcessor {
                         new HashMap<>(),
                         new HashMap<>(),
                         new HashSet<>(),
-                        userConfig.getCustomRuntime()
+                        userConfig.getCustomRuntime(),
+                        userConfig.getLogGroupRetentionInDays()
                 ),
                 new HashSet<>(),
                 new HashSet<>(),
@@ -245,5 +251,6 @@ public class NimbusAnnotationProcessor extends AbstractProcessor {
         }
         return true;
     }
+
 }
 

--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/annotation/processor/UserConfigValidator.kt
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/annotation/processor/UserConfigValidator.kt
@@ -1,0 +1,20 @@
+package com.nimbusframework.nimbusaws.annotation.processor
+
+import com.nimbusframework.nimbuscore.persisted.userconfig.UserConfig
+import javax.annotation.processing.Messager
+
+class UserConfigValidator {
+
+    fun validateUserConfig(userConfig: UserConfig, messager: Messager) {
+        if (userConfig.logGroupRetentionInDays != null && !validLogRetentionDays.contains(userConfig.logGroupRetentionInDays)) {
+            messager.printMessage(javax.tools.Diagnostic.Kind.ERROR, "Log retention days must be one of $validLogRetentionDays")
+        }
+    }
+
+    companion object {
+
+        private val validLogRetentionDays = setOf(1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653)
+
+    }
+
+}

--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/cloudformation/generation/abstractions/FunctionEnvironmentService.kt
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/cloudformation/generation/abstractions/FunctionEnvironmentService.kt
@@ -52,13 +52,10 @@ class FunctionEnvironmentService(
 
         val httpApi = updateTemplate.getOrCreateRootHttpApi(processingData)
 
-//        val apiGatewayHttpDeployment = updateTemplate.getOrCreateRootHttpApiDeployment(processingData)
-
         val httpLambdaIntegration = HttpLambdaIntegration(httpApi, httpFunction.path, httpFunction.method.name, function, nimbusState)
         val restRoute = RestRoute(httpApi, httpFunction.path, httpFunction.method.name, httpLambdaIntegration, updateTemplate.getRestApiAuthorizer(), nimbusState)
 
         restRoute.addDependsOn(httpLambdaIntegration)
-//        apiGatewayHttpDeployment.addDependsOn(restRoute)
         updateResources.addResource(httpLambdaIntegration)
         updateResources.addResource(restRoute)
 

--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/cloudformation/model/resource/ResourceCollection.kt
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/cloudformation/model/resource/ResourceCollection.kt
@@ -129,19 +129,24 @@ class ResourceCollection {
     fun toJson(): JsonObject {
         val resources = JsonObject()
 
+        for (resource in resourceMap.values.toList()) {
+            addAdditionalResources(resource)
+        }
+
         for (resource in resourceMap.values) {
-            processResource(resources, resource)
+            resources.add(resource.getName(), resource.toCloudFormation())
         }
 
         return resources
     }
 
-    private fun processResource(resources: JsonObject, resource: Resource) {
+    private fun addAdditionalResources(resource: Resource) {
         resource.getAdditionalResources().forEach {
-            processResource(resources, it)
+            addResource(it)
+            addAdditionalResources( it)
         }
-        resources.add(resource.getName(), resource.toCloudFormation())
     }
+
 
     fun contains(resource: Resource): Boolean {
         return resourceMap.containsKey(resource.getName())

--- a/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/customRuntimeEntry/CustomRuntimeEntryFileBuilder.kt
+++ b/cloud/aws/src/main/java/com/nimbusframework/nimbusaws/wrappers/customRuntimeEntry/CustomRuntimeEntryFileBuilder.kt
@@ -73,11 +73,11 @@ class CustomRuntimeEntryFileBuilder(
 
         write("case \"$identifier\":")
         val (_, className, inputType, returnType) = functionInformation.awsMethodInformation!!
-        write("\t$className ${className.toLowerCase()} = new ${className}();")
+        write("\t$className ${className.lowercase()} = new ${className}();")
 
         write("\treturn (invocation, context) -> {")
         write("\t$inputType request = objectMapper.readValue(invocation.getEvent(), ${inputType}.class);")
-        write("\t$returnType response = ${className.toLowerCase()}.handleRequest(request, context);")
+        write("\t$returnType response = ${className.lowercase()}.handleRequest(request, context);")
         write("\tcustomRuntimeHandler.sendResponse(response, invocation);")
         write("\t};")
     }

--- a/cloud/aws/src/test/java/com/nimbusframework/nimbusaws/cloudformation/generation/abstractions/FunctionEnvironmentServiceTest.kt
+++ b/cloud/aws/src/test/java/com/nimbusframework/nimbusaws/cloudformation/generation/abstractions/FunctionEnvironmentServiceTest.kt
@@ -42,7 +42,8 @@ class FunctionEnvironmentServiceTest : AnnotationSpec() {
         updateResources.toJson()
 
         createResources.size() shouldBe 1
-        updateResources.size() shouldBe 2
+        // 1 function, 1 IAM role, 1 log group, 1 deployment bucket
+        updateResources.size() shouldBe 4
 
         updateResources.get("NimbusDeploymentBucket") shouldNotBe null
         updateResources.get("ctTesttestMethodFunction") shouldNotBe null

--- a/cloud/aws/src/test/java/com/nimbusframework/nimbusaws/cloudformation/generation/abstractions/FunctionEnvironmentServiceTest.kt
+++ b/cloud/aws/src/test/java/com/nimbusframework/nimbusaws/cloudformation/generation/abstractions/FunctionEnvironmentServiceTest.kt
@@ -1,10 +1,10 @@
 package com.nimbusframework.nimbusaws.cloudformation.generation.abstractions
 
 import com.nimbusframework.nimbusaws.annotation.processor.ProcessingData
-import com.nimbusframework.nimbusaws.cloudformation.generation.abstractions.FunctionEnvironmentService
 import com.nimbusframework.nimbusaws.cloudformation.model.CloudFormationFiles
 import com.nimbusframework.nimbusaws.cloudformation.model.processing.FileBuilderMethodInformation
 import com.nimbusframework.nimbusaws.cloudformation.model.resource.ResourceCollection
+import com.nimbusframework.nimbusaws.cloudformation.model.resource.file.FileBucketResource
 import com.nimbusframework.nimbusaws.cloudformation.model.resource.function.FunctionConfig
 import com.nimbusframework.nimbuscore.persisted.HandlerInformation
 import com.nimbusframework.nimbuscore.persisted.NimbusState
@@ -38,12 +38,47 @@ class FunctionEnvironmentServiceTest : AnnotationSpec() {
 
         underTest.newFunction(fileBuilderMethodInformation, handlerInformation, functionConfig)
 
+        createResources.toJson()
+        updateResources.toJson()
+
         createResources.size() shouldBe 1
         updateResources.size() shouldBe 2
 
         updateResources.get("NimbusDeploymentBucket") shouldNotBe null
         updateResources.get("ctTesttestMethodFunction") shouldNotBe null
         updateResources.getFunction("com.test.Test", "testMethod") shouldNotBe null
+    }
+
+    @Test
+    fun deduplicatesIamRolesForFunctionsAndCreatesSingleLogGroup() {
+        val fileBuilderMethodInformation1 = FileBuilderMethodInformation("Test", null, "testMethod1", "com.test", listOf(), mockk())
+        val fileBuilderMethodInformation2 = FileBuilderMethodInformation("Test", null, "testMethod2", "com.test", listOf(), mockk())
+        val fileBuilderMethodInformation3 = FileBuilderMethodInformation("Test", null, "testMethod3", "com.test", listOf(), mockk())
+        val handlerInformation = HandlerInformation("", "testHandler", "")
+        val functionConfig = FunctionConfig(10, 2000, "dev")
+
+        val functionResource1 = underTest.newFunction(fileBuilderMethodInformation1, handlerInformation, functionConfig)
+        val functionResource2 = underTest.newFunction(fileBuilderMethodInformation2, handlerInformation, functionConfig)
+        val functionResource3 = underTest.newFunction(fileBuilderMethodInformation3, handlerInformation, functionConfig)
+
+        val fakeResource = FileBucketResource(nimbusState, "bucketName", arrayOf(), "dev")
+        functionResource2.iamRoleResource.addAllowStatement("PutLogs", fakeResource, ":*")
+
+        createResources.toJson()
+        updateResources.toJson()
+
+        createResources.size() shouldBe 1
+
+        // 3 functions, 2 IAM roles, 1 log group, 1 deployment bucket
+        updateResources.size() shouldBe 7
+
+        updateResources.get(functionResource1.iamRoleResource.getName()) shouldNotBe null
+        updateResources.get(functionResource2.iamRoleResource.getName()) shouldNotBe null
+        updateResources.get(functionResource2.logGroupResource.getName()) shouldNotBe null
+
+        functionResource1.iamRoleResource.getName() shouldBe functionResource3.iamRoleResource.getName()
+        functionResource1.logGroupResource.getName() shouldBe functionResource2.logGroupResource.getName()
+        functionResource1.iamRoleResource.getName() shouldNotBe functionResource2.iamRoleResource.getName()
     }
 
 }

--- a/core/src/main/java/com/nimbusframework/nimbuscore/persisted/NimbusState.kt
+++ b/core/src/main/java/com/nimbusframework/nimbuscore/persisted/NimbusState.kt
@@ -16,5 +16,6 @@ data class NimbusState(
         val fileUploads: MutableMap<String, MutableMap<String, MutableList<FileUploadDescription>>> = mutableMapOf(),
         val exports: MutableMap<String, MutableList<ExportInformation>> = mutableMapOf(),
         val handlerFiles: MutableSet<HandlerInformation> = mutableSetOf(),
-        val customRuntime: Boolean = false
+        val customRuntime: Boolean = false,
+        val logGroupRetentionInDays: Int? = null
 )

--- a/core/src/main/java/com/nimbusframework/nimbuscore/persisted/userconfig/UserConfig.kt
+++ b/core/src/main/java/com/nimbusframework/nimbuscore/persisted/userconfig/UserConfig.kt
@@ -12,7 +12,8 @@ data class UserConfig(
     val defaultStages: List<String> = listOf(NimbusConstants.stage),
     val keepWarmStages: List<String> = listOf(),
     val defaultAllowedHeaders: List<AllowedHeaders> = listOf(),
-    val defaultAllowedOrigin: List<AllowedOrigin> = listOf()
+    val defaultAllowedOrigin: List<AllowedOrigin> = listOf(),
+    val logGroupRetentionInDays: Int? = null
 ) {
 
     @JsonIgnore


### PR DESCRIPTION
Reduce the number of resources created to help keep within the 500 resource CloudFormation limit in AWS.

Do this in two main ways:
 - Create a single log group across a project, shared by all lambdas, instead of one per lambda.
   - before: per lambda log group called /aws/lambda/functionname
   - after: single log group `ProjectName-stage-logs`, each function will log to a stream with a format like `FunctionName@latest...`, so the logs can still be filtered by function.
 - Only create IAM roles per unique combination of permissions, i.e. if multiple functions use the same permissions, only create one role for those functions to share.

In a personal project, this took the number of resources from 504 down to 345.

Also, add config to specify retention for lambda logs. Defaults to infinite retention (which is the existing behavior).
